### PR TITLE
Fix ObjectPoolV2 const accessor

### DIFF
--- a/include/util/object_pool.hpp
+++ b/include/util/object_pool.hpp
@@ -204,6 +204,7 @@ namespace ModernBoy
             return *slots[handle.index].get();
         }
         const T& operator[](HandleV2 handle) const{
+            if(slots[handle.index].generation != handle.generation)
                 throw std::out_of_range(std::format(
                     "Handle(Index={}) generation {} is mismatched. (valid generation={})",
                     handle.index, handle.generation, slots[handle.index].generation

--- a/test/object_pool.cpp
+++ b/test/object_pool.cpp
@@ -98,3 +98,13 @@ TEST(ObjectPoolV2, RemoveAndReuseWithEntity) {
     EXPECT_EQ(handle3.index, handle1.index);
     EXPECT_EQ(pool[handle3].id, 300);
 }
+
+
+TEST(ObjectPoolV2, ConstAccess){
+    ObjectPoolV2<int> pool;
+    auto handle = pool.emplace(42);
+    const auto& cref = pool;
+    EXPECT_EQ(cref[handle], 42);
+    pool.remove(handle);
+    EXPECT_THROW(cref[handle], std::out_of_range);
+}


### PR DESCRIPTION
## Summary
- fix `ObjectPoolV2` const accessor so it mirrors non-const version
- add regression test for const access

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` *(fails: Could NOT find OpenGL)*
- `sudo apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688ccf645d1c8333bf689dcf21db50bb